### PR TITLE
[Update]Public orders お届け先のボタンとフォームをscriptで制御

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,7 +5,6 @@
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
-
     <script src="https://kit.fontawesome.com/a7eeb2be5e.js" crossorigin="anonymous"></script>
     <%= stylesheet_pack_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>

--- a/app/views/public/orders/new.html.erb
+++ b/app/views/public/orders/new.html.erb
@@ -12,7 +12,7 @@
 　　<h4>注文情報入力</h4>
     </div>
 
-    <%= form_with model: @order, url: "/orders/confirm", method: :post, local: true do |f| %>
+    <%= form_with model: @order, url: "/orders/confirm", method: :post do |f| %>
 
       <h5>支払方法</h5>
       <div class="col">
@@ -60,7 +60,7 @@
             <%= f.label :address, '住所' %>
           </div>
           <div class="col-6">
-            <%= f.text_field :address, class: "form-control rounded " %>
+            <%= f.text_field :address, class: "form-control rounded" %>
           </div>
         </div>
 
@@ -78,3 +78,34 @@
     <% end %>
   </div>
 </div>
+<script>
+  var addressOptionInputs = document.getElementsByName('order[address_option]');
+
+  function handleAddressOptionChange() {
+  var postalCodeInput = document.getElementById('order_postal_code');
+  var addressInput = document.getElementById('order_address');
+  var nameInput = document.getElementById('order_name');
+
+  if (this.value === '0' || this.value === '1') {
+      postalCodeInput.disabled = true;
+      addressInput.disabled = true;
+      nameInput.disabled = true;
+  } else {
+      postalCodeInput.disabled = false;
+      addressInput.disabled = false;
+      nameInput.disabled = false;
+    }
+  }
+
+  for (var i = 0; i < addressOptionInputs.length; i++) {
+    addressOptionInputs[i].addEventListener('change', handleAddressOptionChange);
+  }
+
+  // スクリプトの実行
+  for (var i = 0; i < addressOptionInputs.length; i++) {
+    if(addressOptionInputs[i].checked){
+      handleAddressOptionChange.call(addressOptionInputs[i]);
+      break;
+    }
+  }
+</script>

--- a/app/views/public/orders/new.html.erb
+++ b/app/views/public/orders/new.html.erb
@@ -38,8 +38,8 @@
           <%= f.label :address_option_1,"登録済住所から選択" %>
         </div>
 
-        <div>
-          <%= f.select :address_id, options_from_collection_for_select(current_customer.addresses.all, :id, :address_was) %>
+        <div  class="col offset-md-1 mt-2", style="box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.1); border-radius: 5px; width: 500px;">
+          <%= f.select :address_id, options_from_collection_for_select(current_customer.addresses.all, :id, :address_was), {}, style: "box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.1); border-radius: 5px; width: 500px;" %>
         </div>
 
     　　<div class="col mt-2">


### PR DESCRIPTION
新しいお届け先ボタンを押さないと入力フォームが使えないように<script>を追加
登録済み住所の表示位置を微修正